### PR TITLE
Fix JavaScript errors in proveedores and evaluaciones pages

### DIFF
--- a/js/evaluaciones.js
+++ b/js/evaluaciones.js
@@ -41,7 +41,7 @@ class EvaluacionManager {
 
     async cargarProveedores() {
         try {
-            const proveedores = await this.supabase.obtenerProveedores();
+            const { data: proveedores } = await this.supabase.obtenerProveedores({ porPagina: 0 });
             const select = document.getElementById('selectProveedor');
             select.innerHTML = '<option value="" selected>Seleccione un proveedor...</option>';
             proveedores.forEach(proveedor => {

--- a/js/proveedores.js
+++ b/js/proveedores.js
@@ -196,4 +196,50 @@ class ProveedorManager {
             return;
         }
 
-        const
+        const formData = new FormData(form);
+        const proveedorData = Object.fromEntries(formData.entries());
+
+        // Si estamos editando, añadimos el ID al objeto de datos
+        if (this.proveedorSeleccionado) {
+            proveedorData.id = this.proveedorSeleccionado.id;
+        }
+
+        try {
+            await this.supabase.guardarProveedor(proveedorData);
+            showNotification('Proveedor guardado con éxito', 'success');
+            this.modal.hide();
+        } catch (error) {
+            console.error('Error al guardar proveedor:', error);
+            showNotification('Error al guardar el proveedor.', 'error');
+        }
+    }
+
+    determinarEstado(puntajeAlta, puntajeInterna) {
+        if (puntajeAlta === 0 && puntajeInterna === 0) return 'PENDIENTE';
+        if (puntajeAlta > 80) return 'APROBADO';
+        if (puntajeAlta >= 60 && puntajeAlta <= 80) return 'CONDICIONADO';
+        if (puntajeAlta < 60) return 'RECHAZADO';
+        return 'PENDIENTE';
+    }
+
+    getEstadoBadgeClass(estado) {
+        switch (estado.toLowerCase()) {
+            case 'aprobado': return 'bg-success';
+            case 'condicionado': return 'bg-warning text-dark';
+            case 'rechazado': return 'bg-danger';
+            case 'pendiente': return 'bg-secondary';
+            default: return 'bg-light text-dark';
+        }
+    }
+
+    irAEvaluacion(proveedorId) {
+        window.location.href = `evaluaciones.html?proveedor=${proveedorId}`;
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    // Asegurarnos de que el código solo se ejecute en la página de proveedores
+    if (document.getElementById('proveedoresTableBody')) {
+        new ProveedorManager();
+    }
+});


### PR DESCRIPTION
This commit addresses two critical JavaScript errors:

1.  **SyntaxError in `proveedores.js`**: The file was truncated, leading to an `Unexpected end of input` error. This has been resolved by completing the `ProveedorManager` class, including the `guardarProveedor` method and other missing functions, and adding the necessary closing braces and a `DOMContentLoaded` event listener.

2.  **TypeError in `evaluaciones.js`**: The `cargarProveedores` function was attempting to call `.forEach` on an object instead of an array. This was fixed by correctly destructuring the response from the `obtenerProveedores` service to access the `data` array.

These changes should resolve the errors reported by the user and restore the functionality of the respective pages.