### PR TITLE
Fix(evaluaciones): Round evaluation score to integer before saving

### DIFF
--- a/js/evaluaciones.js
+++ b/js/evaluaciones.js
@@ -320,7 +320,7 @@ class EvaluacionManager {
                 if(checkbox) criterios[`criterio-${criterio.id}`] = checkbox.checked;
             });
 
-            const puntaje = parseFloat(document.getElementById('puntajeTotal').textContent);
+            const puntaje = Math.round(parseFloat(document.getElementById('puntajeTotal').textContent));
             const comentarios = document.getElementById('comentariosEvaluacion').value.trim();
 
             const evaluacionData = {


### PR DESCRIPTION
The application was encountering a database error 'invalid input syntax for type integer' when saving evaluations. This was caused by sending a floating-point number (e.g., "18.5") for the 'puntaje' field, which is defined as an integer in the database schema.

This commit fixes the issue by rounding the calculated score to the nearest whole number using `Math.round()` before it is sent to the database. This ensures the data type is correct and prevents the database error.